### PR TITLE
Optimize execution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		
+		{
+			"name": "(gdb) Launch",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceFolder}/lem-in",
+			"args": [],
+			"stopAtEntry": false,
+			"cwd": "${workspaceFolder}",
+			"environment": [],
+			"externalConsole": false,
+			"MIMode": "gdb",
+			"setupCommands": [
+				{
+					"description": "Enable pretty-printing for gdb",
+					"text": "-enable-pretty-printing",
+					"ignoreFailures": true
+				}
+			]
+		}
+	]
+}

--- a/includes/lem_in.h
+++ b/includes/lem_in.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   lem_in.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 17:16:56 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/14 17:16:56 by tkobb            ###   ########.fr       */
+/*   Updated: 2018/12/17 04:53:31 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ typedef struct		s_node
 {
 	char			*name;
 	UINT			used;
-	struct s_node	*parent;
+	UINT			height;
 	t_flag			flag;
 	t_visited		visited;
 	t_edge			*edges;

--- a/maps/1.map
+++ b/maps/1.map
@@ -1,0 +1,16 @@
+10
+##start
+entree 5 4
+##end
+sortie 5 3
+salle_1 5 4
+salle_10 5 4
+salle_2 5 3
+salle_3 5 3
+entree-sortie
+entree-salle_10
+salle_1-sortie
+salle_1-entree
+salle_2-salle_10
+salle_3-salle_2
+sortie-salle_3

--- a/srcs/execute.c
+++ b/srcs/execute.c
@@ -3,17 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   execute.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 16:00:42 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/14 17:52:52 by mjacques         ###   ########.fr       */
+/*   Updated: 2018/12/17 05:39:39 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
 
 static void	execute_path(t_path *path, UINT *remaining,
-	UINT *arrived, UINT *ant_nbr)
+	UINT *arrived, UINT *ant_nbr, char is_shortest_path)
 {
 	UINT	i;
 
@@ -31,7 +31,7 @@ static void	execute_path(t_path *path, UINT *remaining,
 		}
 		i -= 1;
 	}
-	if (*remaining != 0)
+	if (*remaining != 0 && (is_shortest_path || *remaining >= path->len))
 	{
 		ft_printf("L%d-%s ", *ant_nbr, path->nodes[1]->name);
 		path->nodes[1]->used = *ant_nbr;
@@ -57,7 +57,7 @@ int			execute(t_paths *paths, UINT n_ants)
 		path = paths;
 		while (path)
 		{
-			execute_path(path->path, &remaining, &arrived, &ant_nbr);
+			execute_path(path->path, &remaining, &arrived, &ant_nbr, path->path->len == paths->path->len);
 			path = path->next;
 		}
 		ft_putchar('\n');

--- a/srcs/find_paths.c
+++ b/srcs/find_paths.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   find_paths.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/13 21:41:47 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/14 17:21:18 by tkobb            ###   ########.fr       */
+/*   Updated: 2018/12/17 05:06:12 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,11 +39,10 @@ static void			process_edges(t_node *node, t_queue **queue)
 	edge = node->edges;
 	while (edge)
 	{
-		if ((edge->node->parent == NULL && edge->node->flag != SOURCE)
-			|| (edge->node->flag == SINK && edge->visited == FALSE
-			&& node->visited == FALSE))
+		if ((edge->node->height == 0 && edge->node->flag != SOURCE)
+			|| edge->node->flag == SINK)
 		{
-			edge->node->parent = node;
+			edge->node->height = node->height + 1;
 			queue_add(queue, edge->node);
 		}
 		edge = edge->next;
@@ -72,18 +71,18 @@ int					find_shortest_path(t_node *graph, t_paths **tail)
 	return (0);
 }
 
-void				reset_parents(t_node *graph)
+void				reset_heights(t_node *graph)
 {
 	t_edge	*edge;
 
-	if ((graph->parent == NULL && graph->flag != SOURCE)
+	if ((graph->height == 0 && graph->flag != SOURCE)
 		|| graph->visited == TRUE)
 		return ;
-	graph->parent = NULL;
+	graph->height = 0;
 	edge = graph->edges;
 	while (edge)
 	{
-		reset_parents(edge->node);
+		reset_heights(edge->node);
 		edge = edge->next;
 	}
 }
@@ -101,7 +100,7 @@ t_paths				*find_shortest_paths(t_node *graph, unsigned int n_ants)
 			head = tail;
 		if (tail && tail->path->len >= n_ants)
 			break ;
-		reset_parents(graph);
+		reset_heights(graph);
 	}
 	return (head);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 17:22:15 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/14 17:58:33 by tkobb            ###   ########.fr       */
+/*   Updated: 2018/12/17 05:14:31 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,13 +20,14 @@ int		main(int argc, char **argv)
 	UINT			n_ants;
 
 	map = NULL;
+	int fd = open("maps/1.map", O_RDONLY);
 	if (argc != 1 && argv[0])
 		ft_error("Usage: ./lem-in");
-	if ((n_ants = ants_nbr(0)) == 0)
+	if ((n_ants = ants_nbr(fd)) == 0)
 		exit_lem_in("ERROR", map);
 	if ((map = h_map_create(HASH_MAP_SIZE)) == NULL)
 		exit_lem_in("ERROR", map);
-	if ((graph = parse(0, map)) == NULL)
+	if ((graph = parse(fd, map)) == NULL)
 		exit_lem_in("ERROR", map);
 	if ((paths = find_shortest_paths(graph, n_ants)) == NULL)
 		exit_lem_in("ERROR", map);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 17:22:15 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/17 05:14:31 by theo             ###   ########.fr       */
+/*   Updated: 2018/12/17 05:26:45 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,19 +20,19 @@ int		main(int argc, char **argv)
 	UINT			n_ants;
 
 	map = NULL;
-	int fd = open("maps/1.map", O_RDONLY);
 	if (argc != 1 && argv[0])
 		ft_error("Usage: ./lem-in");
-	if ((n_ants = ants_nbr(fd)) == 0)
+	if ((n_ants = ants_nbr(0)) == 0)
 		exit_lem_in("ERROR", map);
 	if ((map = h_map_create(HASH_MAP_SIZE)) == NULL)
 		exit_lem_in("ERROR", map);
-	if ((graph = parse(fd, map)) == NULL)
+	if ((graph = parse(0, map)) == NULL)
 		exit_lem_in("ERROR", map);
 	if ((paths = find_shortest_paths(graph, n_ants)) == NULL)
 		exit_lem_in("ERROR", map);
 	ft_printf("Ants: %d\n", n_ants);
 	h_map_print(map, HASH_MAP_SIZE);
+	print_paths(paths);
 	execute(paths, n_ants);
 	free_paths(paths);
 	free_map(map, HASH_MAP_SIZE);

--- a/srcs/node.c
+++ b/srcs/node.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   node.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/13 00:06:12 by mjacques          #+#    #+#             */
-/*   Updated: 2018/12/14 15:28:09 by tkobb            ###   ########.fr       */
+/*   Updated: 2018/12/17 04:54:54 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ t_node		*node_create(char *name)
 	new->name = ft_strdup(name);
 	new->used = 0;
 	new->visited = FALSE;
-	new->parent = NULL;
+	new->height = 0;
 	new->flag = REGULAR;
 	new->edges = NULL;
 	return (new);

--- a/srcs/set_path.c
+++ b/srcs/set_path.c
@@ -3,15 +3,39 @@
 /*                                                        :::      ::::::::   */
 /*   set_path.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkobb <tkobb@student.42.fr>                +#+  +:+       +#+        */
+/*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 16:01:05 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/14 17:51:00 by mjacques         ###   ########.fr       */
+/*   Updated: 2018/12/17 05:02:51 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
+#include <limits.h>
 
+static t_node	*neighbor_with_min_height(t_node *node)
+{
+	unsigned int	min_h;
+	t_node			*neighbor_with_min_h;
+	t_edge			*edge;
+
+ 	neighbor_with_min_h = NULL;
+	min_h = UINT_MAX;
+	edge = node->edges;
+	while (edge)
+	{
+		if (edge->node->flag != SINK && edge->node->height < min_h
+			&& edge->node->visited == FALSE && edge->visited == FALSE
+			&& (edge->node->height || edge->node->flag == SOURCE))
+		{
+			min_h = edge->node->height;
+			neighbor_with_min_h = edge->node;
+		}
+		edge = edge->next;
+	}
+	return (neighbor_with_min_h);
+}
+/*
 static t_edge	*get_edge(t_node *from, t_node *to)
 {
 	t_edge	*edge;
@@ -25,13 +49,12 @@ static t_edge	*get_edge(t_node *from, t_node *to)
 	}
 	return (NULL);
 }
-
+*/
 UINT			validate_path(t_node *sink)
 {
 	UINT	len;
 	t_node	*node;
 	t_node	*next;
-	t_edge	*edge;
 
 	len = 0;
 	node = sink;
@@ -39,10 +62,7 @@ UINT			validate_path(t_node *sink)
 	{
 		if (node->flag == SOURCE)
 			return (len);
-		if ((next = node->parent) == NULL)
-			return (0);
-		if ((edge = get_edge(node->parent, node)) == NULL
-			|| edge->visited == TRUE)
+		if ((next = neighbor_with_min_height(node)) == NULL || next->height >= node->height)
 			return (0);
 		len += 1;
 		node = next;
@@ -69,7 +89,7 @@ t_path			*set_path(t_node *sink)
 			break ;
 		len--;
 		node->visited = TRUE;
-		next = node->parent;
+		next = neighbor_with_min_height(node);
 		set_edge_visited(node, next);
 		set_edge_visited(next, node);
 		node = next;

--- a/srcs/set_path.c
+++ b/srcs/set_path.c
@@ -6,7 +6,7 @@
 /*   By: theo <theo@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2018/12/14 16:01:05 by tkobb             #+#    #+#             */
-/*   Updated: 2018/12/17 05:02:51 by theo             ###   ########.fr       */
+/*   Updated: 2018/12/17 05:28:48 by theo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,21 +35,7 @@ static t_node	*neighbor_with_min_height(t_node *node)
 	}
 	return (neighbor_with_min_h);
 }
-/*
-static t_edge	*get_edge(t_node *from, t_node *to)
-{
-	t_edge	*edge;
 
-	edge = from->edges;
-	while (edge)
-	{
-		if (edge->node == to)
-			return (edge);
-		edge = edge->next;
-	}
-	return (NULL);
-}
-*/
 UINT			validate_path(t_node *sink)
 {
 	UINT	len;


### PR DESCRIPTION
Attempt to optimize execution by only sending flow down paths when `n units of flow` > `length of path`, except  for the shortest paths where we should always be sending flow.

For instance, if we have 2 units left and 2 paths of length 2 and 20, we don't want to send a unit down the longest path.